### PR TITLE
fix broken footer styles

### DIFF
--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -1,5 +1,5 @@
 body {font-size: 2em;  padding: 25px 100px 25px 100px; text-align: center; }
-footer { position: absolute; bottom: 15px; right: 15px; }
+footer { margin: 40px 0 20px; }
 .moar {text-align: center; margin-top: 100px; }
 .md-preview, pre { text-align: left; }
 .rendered-preview { border: 1px solid #ccc; padding: 15px; text-align: left; }


### PR DESCRIPTION
Currently, the use of absolute positioning on the footer links means the styles break on smaller screens:

This small edit will allow the links to be clearly visible at the bottom of the page, and not overlapping other content at smaller sizes.

Before:

![image](https://f.cloud.github.com/assets/1319791/2515795/e8296c7e-b446-11e3-8d1a-d2193535e9e0.png)

After:

![image](https://f.cloud.github.com/assets/1319791/2515792/e0ec7d2a-b446-11e3-9189-fe44df4c8857.png)

More design :heart: :soon: :tm: 
