### PR TITLE
Find the soffice executable based on which is there, fail if it's not found

### DIFF
--- a/lib/word-to-markdown.rb
+++ b/lib/word-to-markdown.rb
@@ -44,7 +44,9 @@ class WordToMarkdown
 
   def self.soffice_path
     if RUBY_PLATFORM.include?("darwin")
-      "/Applications/LibreOffice.app/Contents/MacOS/soffice"
+      %w[~/Applications /Applications]
+        .map  { |f| File.join(f, "/LibreOffice.app/Contents/MacOS/soffice") }
+        .find { |f| File.file?(f) } || -> { raise RuntimeError.new("Coudln't find LibreOffice on your machine.") }.call
     else
       soffice_path ||= which("soffice")
       soffice_path ||= which("soffice.bin")


### PR DESCRIPTION
Fixes #35 
