### PR TITLE
Fixed checking of ~/Application

### DIFF
--- a/lib/word-to-markdown.rb
+++ b/lib/word-to-markdown.rb
@@ -45,7 +45,7 @@ class WordToMarkdown
   def self.soffice_path
     if RUBY_PLATFORM.include?("darwin")
       %w[~/Applications /Applications]
-        .map  { |f| File.join(f, "/LibreOffice.app/Contents/MacOS/soffice") }
+        .map  { |f| File.expand_path(File.join(f, "/LibreOffice.app/Contents/MacOS/soffice")) }
         .find { |f| File.file?(f) } || -> { raise RuntimeError.new("Coudln't find LibreOffice on your machine.") }.call
     else
       soffice_path ||= which("soffice")

--- a/lib/word-to-markdown.rb
+++ b/lib/word-to-markdown.rb
@@ -46,7 +46,7 @@ class WordToMarkdown
     if RUBY_PLATFORM.include?("darwin")
       %w[~/Applications /Applications]
         .map  { |f| File.expand_path(File.join(f, "/LibreOffice.app/Contents/MacOS/soffice")) }
-        .find { |f| File.file?(f) } || -> { raise RuntimeError.new("Coudln't find LibreOffice on your machine.") }.call
+        .find { |f| File.file?(f) } || -> { raise RuntimeError.new("Couldn't find LibreOffice on your machine.") }.call
     else
       soffice_path ||= which("soffice")
       soffice_path ||= which("soffice.bin")


### PR DESCRIPTION
#36 doesn't properly check for existence of LibreOffice in ~/Application (as per issue #35). Ruby doesn't recognize tildes in file paths, so something like `File.file?("~/Applications/LibreOffice.app/Contents/MacOS/soffice")` will always return `false`. `File.expand_path` will expand the tilde to point to the home directory and fix this issue.