### PR TITLE
Add LibreOffice to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A Ruby gem to liberate content from [the jail that is Word documents](http://ben
 
 ## Install
 
+You'll need to install [LibreOffice](http://www.libreoffice.org/). Then:
+
 ```bash
 gem install word-to-markdown
 ```


### PR DESCRIPTION
I installed this today using the install directions, but it broke on errors due to not having LibreOffice. Since this is a requirement, it'd be good to include it in the installation instructions.