### PR TITLE
Use Cliver to manage soffice dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: "200"
+    - ruby_version: "210"
 
 artifacts:
   - path: install_log.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,3 +22,5 @@ artifacts:
 
 cache:
   - bundle
+
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,4 +23,4 @@ artifacts:
 cache:
   - bundle
 
-build: off
+build: false

--- a/bin/w2m
+++ b/bin/w2m
@@ -9,7 +9,7 @@ end
 
 if ARGV[0] == "--version"
   puts "WordToMarkdown v#{WordToMarkdown::VERSION}"
-  puts "LibreOffice #{WordToMarkdown.soffice_version}"
+  puts "LibreOffice v#{WordToMarkdown.soffice.version}"
 else
   doc = WordToMarkdown.new ARGV[0]
   puts doc.to_s

--- a/lib/cliver/dependency_ext.rb
+++ b/lib/cliver/dependency_ext.rb
@@ -1,0 +1,27 @@
+require 'sys/proctable'
+
+module Cliver
+  class Dependency
+
+    include Sys
+
+    # Memoized shortcut for detect
+    # Returns the path to the detected dependency
+    # Raises an error if the dependency was not satisfied
+    def path
+      @detected_path ||= detect!
+    end
+
+    # Is the detected dependency currently open?
+    def open?
+      ProcTable.ps.any? { |p| p.exe == path }
+    end
+
+    # Returns the version of the resolved dependency
+    def version
+      return @detected_version if defined? @detected_version
+      version = installed_versions.find { |p, v| p == path }
+      @detected_version = version.nil? ? nil : version[1]
+    end
+  end
+end

--- a/test/test_word_to_markdown.rb
+++ b/test/test_word_to_markdown.rb
@@ -55,6 +55,6 @@ class TestWordToMarkdown < Minitest::Test
   end
 
   should "know the soffice version" do
-    assert_match /\d\.\d\.\d\.\d .*/, WordToMarkdown.soffice_version
+    assert_match /\d\.\d\.\d\.\d/, WordToMarkdown.soffice.version
   end
 end

--- a/word-to-markdown.gemspec
+++ b/word-to-markdown.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
     "lib/word-to-markdown/document.rb",
     "lib/word-to-markdown/converter.rb",
     "lib/nokogiri/xml/element.rb",
+    "lib/cliver/dependency_ext.rb",
     "bin/w2m"
   ]
   s.executables = ["w2m"]
@@ -23,6 +24,8 @@ Gem::Specification.new do |s|
   s.add_dependency("premailer", "~> 1.8")
   s.add_dependency("nokogiri-styles", "~> 0.1")
   s.add_dependency("sys-proctable", "~> 0.9")
+  s.add_dependency("cliver", "~> 0.3")
+
   s.add_development_dependency("rake", "~> 10.4")
   s.add_development_dependency("shoulda", "~> 3.5")
   s.add_development_dependency("bundler", "~> 1.6")


### PR DESCRIPTION
This moves to using Cliver to manage the `soffice` dependency.

Specifically:

* Implement a version requirement (`> 4.0`)
* Prefer system path to OS-specific paths
* Support for multiple versions installed
* Use a more OO-like `soffice` object with `open?`, `path`, and `version` methods