### PR TITLE
Add Docker to run executable in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.5
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ghostscript \
+      libfontconfig \
+      libreoffice-writer \
+      libxslt1-dev
+
+RUN gem install word-to-markdown --no-rdoc --no-ri
+
+WORKDIR /app
+
+CMD echo "Nothing to run"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Word-to-markdown requires `soffice` a command line interface to LibreOffice that
 script/cibuild
 ```
 
+## Docker
+
+Everything you need to run the executable locally
+
+```
+docker-compose build
+docker-compose run --rm app w2m --help
+docker-compose run --rm app w2m test/fixtures/em.docx
+```
+
 ## Server
 
 [Word-to-markdown-demo](https://github.com/benbalter/word-to-markdown-demo) contains a lightweight server for converting Word Documents as a service.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.2'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app:delegated


### PR DESCRIPTION
I wanted to run `w2m` locally without installing all the dependencies. Docker to the rescue.