### PR TITLE
fix(readme): docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,18 @@ script/cibuild
 
 ## Docker
 
-Everything you need to run the executable locally
+First, create the `Gemfile.lock` by installing the dependencies:
+
+```
+bundle install
+```
+
+Everything you need to run the executable locally:
 
 ```
 docker-compose build
-docker-compose run --rm app w2m --help
-docker-compose run --rm app w2m test/fixtures/em.docx
+docker-compose run --rm app bundle exec w2m --help
+docker-compose run --rm app bundle exec w2m test/fixtures/em.docx
 ```
 
 ## Hosted service


### PR DESCRIPTION
Without including `bundle exec` in the `docker-compose` coommand, I received this error:

```
word-to-markdown(master*)  > docker-compose run --rm app w2m test/fixtures/em.docx
Creating word-to-markdown_app_run ... done
Traceback (most recent call last):
	2: from /bin/w2m:4:in `<main>'
	1: from /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- word-to-markdown (LoadError)
```

Not that familiar with Ruby, but I think it's because in `bin/w2m` it requires `word-to-markdown` and is filled in by `bundle`

Also, there's an error when building if you don't have a `Gemfile.lock` so I included a step in the instructions

-----
[View rendered README.md](https://github.com/fouad/word-to-markdown/blob/patch-1/README.md)