### PR TITLE
Modernize CI Ruby matrix and fix rubocop config failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['3.2', '3.3', '3.4']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,17 +1,22 @@
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-performance
   - rubocop-minitest
 
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 3.2
 
 Style/Documentation:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Naming/FileName:
+  Enabled: false
+
+# Development dependencies are intentionally declared in the gemspec.
+Gemspec/DevelopmentDependencies:
   Enabled: false

--- a/bin/w2m
+++ b/bin/w2m
@@ -13,5 +13,5 @@ if ARGV[0] == '--version'
   puts "LibreOffice v#{WordToMarkdown.soffice.version}" unless Gem.win_platform?
 else
   doc = WordToMarkdown.new ARGV[0]
-  puts doc.to_s
+  puts doc
 end

--- a/lib/word-to-markdown.rb
+++ b/lib/word-to-markdown.rb
@@ -100,7 +100,7 @@ class WordToMarkdown
     #    and will shell out to `soffice.exe --version`
     # In order to support Windows, don't pass *any* version requirement to Cliver
     def soffice_dependency_args
-      args = [path: PATHS.join(File::PATH_SEPARATOR)]
+      args = [{ path: PATHS.join(File::PATH_SEPARATOR) }]
       if Gem.win_platform?
         args
       else

--- a/lib/word-to-markdown/document.rb
+++ b/lib/word-to-markdown/document.rb
@@ -80,7 +80,7 @@ class WordToMarkdown
       string.sub!(/\A[[:space:]]+/, '') # document leading whitespace
       string.sub!(/[[:space:]]+\z/, '') # document trailing whitespace
       string.gsub!(/([ ]+)$/, '')       # line trailing whitespace
-      string.gsub!(/\n\n\n\n/, "\n\n")  # Quadruple line breaks
+      string.gsub!("\n\n\n\n", "\n\n")  # Quadruple line breaks
       string.delete!(' ')               # Unicode non-breaking spaces, injected as tabs
       string.gsub!(/\*\*\ +(?!\*|_)([[:punct:]])/, '**\1') # Remove extra space after bold
       string

--- a/word-to-markdown.gemspec
+++ b/word-to-markdown.gemspec
@@ -16,8 +16,11 @@ Gem::Specification.new do |s|
   s.bindir = 'bin'
   s.executables = ['w2m']
 
+  s.required_ruby_version = '>= 3.2'
+
   s.add_dependency('cliver', '~> 0.3')
   s.add_dependency('descriptive_statistics', '~> 2.5')
+  s.add_dependency('logger', '~> 1.4')
   s.add_dependency('nokogiri-styles', '~> 0.1')
   s.add_dependency('premailer', '~> 1.8')
   s.add_dependency('reverse_markdown', '>= 1', '< 3')


### PR DESCRIPTION
## Root cause

CI's `test (2.7)` / `test (3.0)` jobs were failing, but **not** because of the Ruby version and **not** because of the `sys-proctable` `/proc/*/fd: Permission denied` warnings (those are unrelated noise). Confirmed from the CI log: `rake test` passed on every Ruby version (36 runs, 43 assertions, 0 failures). The job died at the `rubocop` step:

```
Error: The `Metrics/LineLength` cop has been moved to `Layout/LineLength`.
(obsolete configuration found in .rubocop.yml, please update it)
##[error]Process completed with exit code 2.
```

`script/cibuild` runs `bundle exec rubocop` under `set -e`, so this obsolete-config error (introduced by a newer rubocop version, not by Ruby) failed the whole build.

## Changes

- **`.rubocop.yml`**: rename `Metrics/LineLength` → `Layout/LineLength`, migrate `require:` → `plugins:` for the rubocop extensions, add `TargetRubyVersion: 3.2`, and disable `Gemspec/DevelopmentDependencies` (dev deps intentionally kept in the gemspec).
- **Lint autocorrections** surfaced by the newer rubocop, all semantically equivalent: `bin/w2m`, `lib/word-to-markdown.rb`, `lib/word-to-markdown/document.rb`.
- **`.github/workflows/ci.yml`**: drop EOL Ruby 2.7/3.0, test on **3.2 / 3.3 / 3.4**; bump `actions/checkout@v3` → `@v4`.
- **`word-to-markdown.gemspec`**: set `required_ruby_version = '>= 3.2'`; add explicit `logger` runtime dependency (required directly by `lib/word-to-markdown.rb`; being extracted from default gems in Ruby 3.5).

## Local verification (Ruby 3.4)

Full `script/cibuild` sequence is green:
- `w2m --version` → OK
- `rake test` → 36 runs, 0 failures, 0 errors, 1 skip
- `rubocop` → no offenses
- `gem build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)